### PR TITLE
Ollamaバージョンチェック機能の追加

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -28,6 +28,8 @@ If the file size becomes large, divide the module based on the following points.
 
 ## Finally Check
 
+- Check test:
+    - `make test`
 - Check build:
     - `make build`
 - Check run:
@@ -39,8 +41,8 @@ If the user wants a pull request, follow it. However, make sure you can run [Fin
 
 - `git --no-pager diff origin/main` to check the current status of the difference before creating a pull request.
 - The branch name starts with `feature/` or `fix/`.
-- Write the content of the pull request in Japanese.
-- The content of the pull request includes the following items.
+- Write the title and body of the pull request in Japanese.
+- The body of the pull request includes the following items.
     - What did you do?
     - Why did you do that?
     - How did you do that?

--- a/Makefile
+++ b/Makefile
@@ -14,5 +14,8 @@ install:
 uninstall:
 	rm $(GOPATH)/bin/$(APP_NAME)
 
+test:
+	go test ./src/...
+
 clean:
 	rm -rf $(DIST_DIR)

--- a/src/main.go
+++ b/src/main.go
@@ -7,11 +7,18 @@ import (
 )
 
 func main() {
-	message := flag.String("ollamaHost", "http://localhost:11434/", "Ollama host")
+	host := flag.String("ollamaHost", "http://localhost:11434/", "Ollama host")
 	model := flag.String("ollamaModel", "llama3.2:latest", "Ollama model")
 	flag.Parse()
-	fmt.Println("Ollama Host: " + *message)
-	fmt.Println("Ollama Model: " + *model)
+	fmt.Println("🌐 Ollama Host: " + *host)
+	fmt.Println("🤖 Ollama Model: " + *model)
+
+	version, err := checkOllamaVersion(*host)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println("🛠️ Ollama Version:", version)
 
 	// Execute the command to get the current branch name
 	branchCmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
@@ -22,7 +29,7 @@ func main() {
 	}
 
 	// Print the current branch name
-	fmt.Println("Current Branch: " + string(branchOutput))
+	fmt.Println("🌿 Current Branch: " + string(branchOutput))
 
 	// Execute the git diff command
 	cmd := exec.Command("git", "diff", "--name-status")

--- a/src/ollama.go
+++ b/src/ollama.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+type VersionResponse struct {
+	Version string `json:"version"`
+}
+
+func checkOllamaVersion(host string) (string, error) {
+	resp, err := http.Get(host + "api/version")
+	if err != nil {
+		return "", fmt.Errorf("error fetching Ollama version: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading response body: %w", err)
+	}
+
+	var versionResp VersionResponse
+	if err := json.Unmarshal(body, &versionResp); err != nil {
+		return "", fmt.Errorf("error parsing JSON: %w", err)
+	}
+
+	return versionResp.Version, nil
+}

--- a/src/ollama_test.go
+++ b/src/ollama_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCheckOllamaVersion(t *testing.T) {
+	// Create a test server with a mock response
+	mockResponse := `{"version": "0.5.1"}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	// Call the function with the test server URL
+	version, err := checkOllamaVersion(server.URL + "/")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	// Verify the version
+	expectedVersion := "0.5.1"
+	if version != expectedVersion {
+		t.Errorf("Expected version %s, got %s", expectedVersion, version)
+	}
+}
+
+func TestCheckOllamaVersionError(t *testing.T) {
+	// Create a test server that returns an error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	// Call the function with the test server URL
+	_, err := checkOllamaVersion(server.URL + "/")
+	if err == nil {
+		t.Fatal("Expected an error, got none")
+	}
+}


### PR DESCRIPTION
## 何をしたか\nOllamaのバージョンをチェックする機能を追加しました。\n\n## なぜそれをしたか\nOllamaのバージョン情報を取得する必要があったためです。\n\n## どのようにそれをしたか\n新しい関数checkOllamaVersionを追加し、HTTPリクエストを通じてバージョン情報を取得します。また、テストを追加して機能の確認を行いました。\n\n## どのように確認したか\nMakefileにテストコマンドを追加し、テストを実行して機能が正しく動作することを確認しました。